### PR TITLE
Fix chat loading state lost on navigation

### DIFF
--- a/KlaudimeroApp/KlaudimeroApp.xcodeproj/project.pbxproj
+++ b/KlaudimeroApp/KlaudimeroApp.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		A10000010000000000000010 /* ChatSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000010 /* ChatSession.swift */; };
 		A10000010000000000000011 /* ChatListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000011 /* ChatListView.swift */; };
 		A10000010000000000000012 /* ChatDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000012 /* ChatDetailView.swift */; };
+		A10000010000000000000013 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000013 /* ChatViewModel.swift */; };
+		A10000010000000000000014 /* ChatStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000014 /* ChatStore.swift */; };
 		MD000001000000000000001A /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = MD000001000000000000001B /* MarkdownUI */; };
 /* End PBXBuildFile section */
 
@@ -47,6 +49,8 @@
 		A20000010000000000000010 /* ChatSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSession.swift; sourceTree = "<group>"; };
 		A20000010000000000000011 /* ChatListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListView.swift; sourceTree = "<group>"; };
 		A20000010000000000000012 /* ChatDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDetailView.swift; sourceTree = "<group>"; };
+		A20000010000000000000013 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		A20000010000000000000014 /* ChatStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStore.swift; sourceTree = "<group>"; };
 		A30000010000000000000001 /* KlaudimeroApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KlaudimeroApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C52510962F517FE900731DE3 /* KlaudimeroApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KlaudimeroApp.entitlements; sourceTree = "<group>"; };
 		C52510972F51802D00731DE3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -81,6 +85,7 @@
 				A40000010000000000000003 /* Models */,
 				A40000010000000000000004 /* Services */,
 				A40000010000000000000005 /* Views */,
+				A40000010000000000000007 /* ViewModels */,
 			);
 			path = KlaudimeroApp;
 			sourceTree = "<group>";
@@ -121,6 +126,15 @@
 				A20000010000000000000012 /* ChatDetailView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		A40000010000000000000007 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				A20000010000000000000013 /* ChatViewModel.swift */,
+				A20000010000000000000014 /* ChatStore.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		A40000010000000000000006 /* Products */ = {
@@ -207,6 +221,8 @@
 				A10000010000000000000010 /* ChatSession.swift in Sources */,
 				A10000010000000000000011 /* ChatListView.swift in Sources */,
 				A10000010000000000000012 /* ChatDetailView.swift in Sources */,
+				A10000010000000000000013 /* ChatViewModel.swift in Sources */,
+				A10000010000000000000014 /* ChatStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KlaudimeroApp/KlaudimeroApp/KlaudimeroApp.swift
+++ b/KlaudimeroApp/KlaudimeroApp/KlaudimeroApp.swift
@@ -9,6 +9,7 @@ class NavigationState: ObservableObject {
 struct KlaudimeroApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var navigationState = NavigationState.shared
+    @StateObject private var chatStore = ChatStore.shared
 
     var body: some Scene {
         WindowGroup {
@@ -28,6 +29,7 @@ struct KlaudimeroApp: App {
             }
             .environmentObject(APIClient.shared)
             .environmentObject(navigationState)
+            .environmentObject(chatStore)
             .sheet(item: $navigationState.pendingExecutionId) { executionId in
                 NavigationStack {
                     ExecutionLoadingView(executionId: executionId)

--- a/KlaudimeroApp/KlaudimeroApp/ViewModels/ChatStore.swift
+++ b/KlaudimeroApp/KlaudimeroApp/ViewModels/ChatStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Keeps ChatViewModel instances alive across navigation so that pending
+/// responses and loading state are preserved when the user navigates away
+/// from and back into a chat session.
+@MainActor
+class ChatStore: ObservableObject {
+    static let shared = ChatStore()
+
+    private var viewModels: [String: ChatViewModel] = [:]
+
+    private init() {}
+
+    func viewModel(for sessionId: String, api: APIClient) -> ChatViewModel {
+        if let existing = viewModels[sessionId] {
+            return existing
+        }
+        let vm = ChatViewModel(sessionId: sessionId, api: api)
+        viewModels[sessionId] = vm
+        return vm
+    }
+
+    func remove(sessionId: String) {
+        viewModels.removeValue(forKey: sessionId)
+    }
+}

--- a/KlaudimeroApp/KlaudimeroApp/ViewModels/ChatViewModel.swift
+++ b/KlaudimeroApp/KlaudimeroApp/ViewModels/ChatViewModel.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+@MainActor
+class ChatViewModel: ObservableObject {
+    @Published var session: ChatSession?
+    @Published var isSending = false
+    @Published var isLoading = false
+    @Published var error: String?
+
+    let sessionId: String
+    private let api: APIClient
+
+    init(sessionId: String, api: APIClient) {
+        self.sessionId = sessionId
+        self.api = api
+    }
+
+    func loadSessionIfNeeded() async {
+        guard session == nil && !isLoading else { return }
+        await loadSession()
+    }
+
+    func loadSession() async {
+        isLoading = true
+        do {
+            session = try await api.getChatSession(sessionId)
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func sendMessage(_ content: String) async {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isSending else { return }
+
+        // Optimistically add user message
+        session?.messages.append(ChatMessage(role: "user", content: trimmed))
+
+        isSending = true
+        do {
+            let response = try await api.sendChatMessage(sessionId: sessionId, content: trimmed)
+            session?.messages.append(ChatMessage(role: "assistant", content: response))
+            // Update title from first user message if still empty
+            if session?.title.isEmpty == true {
+                session?.title = String(trimmed.prefix(50))
+            }
+        } catch {
+            self.error = error.localizedDescription
+            // Remove the optimistic user message on failure
+            if session?.messages.last?.role == "user" {
+                session?.messages.removeLast()
+            }
+        }
+        isSending = false
+    }
+}

--- a/KlaudimeroApp/KlaudimeroApp/Views/ChatListView.swift
+++ b/KlaudimeroApp/KlaudimeroApp/Views/ChatListView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ChatListView: View {
     @EnvironmentObject var api: APIClient
+    @EnvironmentObject var chatStore: ChatStore
     @State private var sessions: [ChatSessionSummary] = []
     @State private var isLoading = false
     @State private var error: String?
@@ -81,6 +82,7 @@ struct ChatListView: View {
         Task {
             for session in toDelete {
                 try? await api.deleteChatSession(session.id)
+                chatStore.remove(sessionId: session.id)
             }
         }
     }


### PR DESCRIPTION
## Problem

When a chat had a pending response and the user navigated away, re-entering the chat showed no loading indicator and the response appeared to be lost (though it was still running silently in the background).

## Root Cause

`ChatDetailView` was a plain SwiftUI struct with `@State` properties (`isSending`, `session`). SwiftUI recreates struct state from scratch on every navigation push, orphaning the in-flight task and resetting `isSending` to `false`.

## Fix

- **`ChatViewModel`** — new `ObservableObject` class owning all session/sending/loading state. As a reference type, its state survives navigation.
- **`ChatStore`** — new singleton holding a `[sessionId: ChatViewModel]` dictionary, returning the same instance every time a session is opened.
- **`ChatDetailView`** — refactored into an outer shell that looks up the VM from `ChatStore` + an inner `ChatDetailContentView` using `@ObservedObject`.
- **`ChatListView`** — calls `chatStore.remove(sessionId:)` on deletion to prevent stale VMs accumulating.
- **`KlaudimeroApp`** — injects `ChatStore.shared` as `.environmentObject`.

## Test plan

- [ ] Start a chat and send a message while response is pending
- [ ] Navigate away to another tab or back to the list
- [ ] Re-enter the chat — loading indicator should still be visible
- [ ] Response should appear normally when complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)